### PR TITLE
コンポーネントのexport

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 /* eslint react-hooks/exhaustive-deps: off */
 import React, { useEffect, useState } from "react";
-import ColorfulMessage from "./components/ColorfulMessage";
+import { ColorfulMessage } from "./components/ColorfulMessage";
 
 const App = () => {
   // ステートを変更させる変数、関数、初期値を定義

--- a/src/components/ColorfulMessage.jsx
+++ b/src/components/ColorfulMessage.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 // 設定したpropが渡ってくる
-const ColorfulMessage = (props) => {
+export const ColorfulMessage = (props) => {
   // 分割代入
   const { color, children } = props;
   const contentStyle = {
@@ -12,5 +12,3 @@ const ColorfulMessage = (props) => {
   };
   return <p style={contentStyle}>{children}</p>;
 };
-
-export default ColorfulMessage;


### PR DESCRIPTION
分割代入で表すこともでき、この手法だと関数のスペルミスを発見しやすい(エラーが出るため)